### PR TITLE
fix: Resolve compilation errors and CLI argument conflicts

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -72,7 +72,7 @@ enum Commands {
         #[arg(short = 'C', long)]
         category: Option<String>,
         /// Filter by priority
-        #[arg(short, long, value_enum)]
+        #[arg(short = 'P', long, value_enum)]
         priority: Option<PriorityArg>,
         /// Show overdue tasks only
         #[arg(short, long)]

--- a/src/models.rs
+++ b/src/models.rs
@@ -588,8 +588,8 @@ mod tests {
     #[test]
     fn test_task_update_builder_with_none_values() {
         let update = TaskUpdate::new()
-            .description(None)
-            .category(None)
+            .description(None::<String>)
+            .category(None::<String>)
             .due_date(None);
 
         assert_eq!(update.description, Some(None));
@@ -705,8 +705,8 @@ mod tests {
         );
 
         let update = TaskUpdate::new()
-            .description(None)
-            .category(None);
+            .description(None::<String>)
+            .category(None::<String>);
 
         let result = todo_list.update_task(id, update);
         assert!(result.is_ok());


### PR DESCRIPTION
- Fix type inference errors in TaskUpdate tests by specifying None::<String>
- Resolve CLI argument conflict between pending (-p) and priority (-p) flags
- Change priority flag to use -P (capital P) for short option to avoid conflict
- All tests now pass and CLI functionality is fully operational

🤖 Generated with [Claude Code](https://claude.ai/code)