### PR TITLE
feat: Add before/after comparison to edit command

### DIFF
--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -175,8 +175,9 @@ fn test_edit_todo_title() {
 
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
-    assert!(stdout.contains("Updated:"));
-    assert!(stdout.contains("Updated title"));
+    assert!(stdout.contains("Updated task [1]"));
+    assert!(stdout.contains("Changes:"));
+    assert!(stdout.contains("Title: Original title → Updated title"));
 }
 
 #[test]
@@ -200,8 +201,13 @@ fn test_edit_todo_all_fields() {
 
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
-    assert!(stdout.contains("Updated:"));
-    assert!(stdout.contains("Edited task"));
+    assert!(stdout.contains("Updated task [1]"));
+    assert!(stdout.contains("Changes:"));
+    assert!(stdout.contains("Title: Task to edit → Edited task"));
+    assert!(stdout.contains("Description: (none) → New description"));
+    assert!(stdout.contains("Due date: (none) → 2024-12-25"));
+    assert!(stdout.contains("Category: (none) → personal"));
+    assert!(stdout.contains("Priority: medium → low"));
 }
 
 #[test]
@@ -409,7 +415,10 @@ fn test_edit_clear_fields() {
 
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
-    assert!(stdout.contains("Updated:"));
+    assert!(stdout.contains("Updated task [1]"));
+    assert!(stdout.contains("Changes:"));
+    assert!(stdout.contains("Description: Original description → (none)"));
+    assert!(stdout.contains("Category: work → (none)"));
 }
 
 #[test]
@@ -432,7 +441,9 @@ fn test_mark_incomplete() {
 
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
-    assert!(stdout.contains("Updated:"));
+    assert!(stdout.contains("Updated task [1]"));
+    assert!(stdout.contains("Changes:"));
+    assert!(stdout.contains("Status: completed → incomplete"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Enhances the existing edit command to show detailed before/after comparison when updating tasks, addressing issue #9 requirement for "Show before/after comparison".

## Changes Made

### Enhanced Edit Command Output
- **Before/After Comparison**: Shows detailed comparison of changed fields using colored output
- **Field-by-Field Display**: Each modified field shows `old value → new value` format
- **No Changes Handling**: Displays "No changes made" when no modifications are applied
- **Status Change Tracking**: Captures completion status changes when using `--incomplete` flag

### Output Examples

**Multiple Field Changes:**
```
Updated task [1]
Changes:
  Title: Original title → Updated title
  Description: Old description → New description
  Category: work → personal
  Priority: high → low
```

**Clearing Fields:**
```
Updated task [1]
Changes:
  Description: Some description → (none)
  Category: work → (none)
```

**No Changes:**
```
Updated task [1]
  No changes made
```

## Technical Implementation

### Core Features
- **Comparison Function**: New `show_task_comparison()` function handles field-by-field comparison
- **State Capture**: Task state is captured before modifications for accurate comparison
- **Colored Output**: Uses existing colored crate for visual distinction (red → green)
- **Comprehensive Coverage**: Handles all editable fields (title, description, due date, category, priority, completion status)

### Test Updates
- **Updated All Edit Tests**: Modified existing tests to expect new comparison format
- **Enhanced Assertions**: Tests now verify specific before/after field changes
- **Comprehensive Coverage**: Tests cover all scenarios (changes, clearing fields, no changes, status changes)

## Issue Resolution

Closes #9 - All acceptance criteria fulfilled:

✅ **Accept task ID as required argument** - Already implemented
✅ **Allow updating any field** - Already implemented  
✅ **Show before/after comparison** - ✨ **New feature added**
✅ **Handle partial updates** - Already implemented
✅ **Validate new values before applying** - Already implemented

## Backwards Compatibility

- **Full Compatibility**: All existing edit command functionality preserved
- **Same Interface**: No changes to command line arguments or flags
- **Enhanced Output**: Only the output format is improved, no breaking changes
- **Test Updates**: Updated tests reflect new expected behavior

## Example Usage

All existing usage patterns work exactly the same, with enhanced output:

```bash
# Edit title and priority
rtodo edit 5 --title "New title" --priority high

# Clear description and category  
rtodo edit 5 --description "none" --category "none"

# Mark as incomplete with title change
rtodo edit 5 --title "Updated title" --incomplete
```

🤖 Generated with [Claude Code](https://claude.ai/code)